### PR TITLE
修復白天/黑天模式切換時位置跳動

### DIFF
--- a/source/css/main.css
+++ b/source/css/main.css
@@ -91,7 +91,7 @@ figure {
 
 
 
-body ,html[data-theme=dark]{
+html, body {
   min-height: 100vh;
   overflow-x: hidden;
   position: relative;


### PR DESCRIPTION
問題：
切換白天/黑天模式時，頁面高度或元素位置會跳動。

原因：
原本 CSS 選擇器 body, html[data-theme=dark 導致 light/dark 模式下 rem 基準不一致。

解決方式：
將選擇器改為 html, body，統一 font-size，確保 rem 基準一致，切換主題時不再跳動。